### PR TITLE
Add new ESLint rule to enforce new with Error and CoreError constructors

### DIFF
--- a/eslint-plugin-divvy-rules/index.js
+++ b/eslint-plugin-divvy-rules/index.js
@@ -18,9 +18,21 @@ const useUserFacingError = {
   }),
 };
 
+const useNewWithError = {
+  create: context => ({
+    CallExpression: node => {
+      const { name } = node.callee;
+      if (name === 'Error' || name === 'CoreError') {
+        context.report({ node, message: `Use \`new ${name}()\`` });
+      }
+    },
+  }),
+};
+
 module.exports = {
   rules: {
     'use-core-error': useCoreError,
     'use-user-facing-error': useUserFacingError,
+    'use-new-with-error': useNewWithError,
   },
 };

--- a/index.js
+++ b/index.js
@@ -134,8 +134,9 @@ module.exports = {
 
     "no-only-tests/no-only-tests": "error",
 
-    "divvy-rules/use-core-error": "error",
-    "divvy-rules/use-user-facing-error": "error"
+    "divvy-rules/use-core-error": "warn",
+    "divvy-rules/use-user-facing-error": "warn",
+    "divvy-rules/use-new-with-error": "error"
   },
 
   settings: {


### PR DESCRIPTION
Also, downgrade use CoreError rules to warning to stay in sync with divvy-homes repo